### PR TITLE
fix: avoid double cloning note in notes listener

### DIFF
--- a/crates/zoroswap/src/notes_listener.rs
+++ b/crates/zoroswap/src/notes_listener.rs
@@ -76,7 +76,7 @@ impl NotesListener {
 
                     for note in valid_notes.iter() {
                         let note_miden_id = note.id();
-                        match self.state.add_order(note.to_owned().clone()) {
+                        match self.state.add_order(note.clone()) {
                             Ok((note_id, order_id, order)) => {
                                 // Track this note as processed to avoid duplicates
                                 processed_notes.insert(note_miden_id);


### PR DESCRIPTION
The notes listener was calling note.to_owned().clone(), which creates two independent copies of the same Note. Since add_order only needs a single owned Note, cloning once is sufficient. This change reduces unnecessary allocations and extra work in the hot path that processes committed notes.