### PR TITLE
chore: avoid unnecessary clones when creating notes

### DIFF
--- a/crates/zoroswap/src/common.rs
+++ b/crates/zoroswap/src/common.rs
@@ -196,8 +196,8 @@ pub fn create_zoroswap_note(
     )?;
 
     let assets = NoteAssets::new(assets)?;
-    let recipient = NoteRecipient::new(swap_serial_num, note_script.clone(), inputs.clone());
-    let note = Note::new(assets.clone(), metadata, recipient.clone());
+    let recipient = NoteRecipient::new(swap_serial_num, note_script, inputs);
+    let note = Note::new(assets, metadata, recipient);
 
     Ok(note)
 }
@@ -252,8 +252,8 @@ pub fn create_deposit_note(
     )?;
 
     let assets = NoteAssets::new(assets)?;
-    let recipient = NoteRecipient::new(swap_serial_num, note_script.clone(), inputs.clone());
-    let note = Note::new(assets.clone(), metadata, recipient.clone());
+    let recipient = NoteRecipient::new(swap_serial_num, note_script, inputs);
+    let note = Note::new(assets, metadata, recipient);
 
     Ok(note)
 }
@@ -308,8 +308,8 @@ pub fn create_withdraw_note(
     )?;
 
     let assets = NoteAssets::new(assets)?;
-    let recipient = NoteRecipient::new(swap_serial_num, note_script.clone(), inputs.clone());
-    let note = Note::new(assets.clone(), metadata, recipient.clone());
+    let recipient = NoteRecipient::new(swap_serial_num, note_script, inputs);
+    let note = Note::new(assets, metadata, recipient);
 
     Ok(note)
 }


### PR DESCRIPTION
Note creation helpers in common.rs were cloning note_script, inputs, assets and the recipient before passing them into NoteRecipient::new and Note::new, even though these values were freshly constructed and not reused afterwards. The miden-client APIs consume these arguments by value, and other call sites in the codebase already pass ownership directly. This change removes the redundant clones in create_zoroswap_note, create_deposit_note and create_withdraw_note to avoid extra allocations and keep the code consistent with the rest of the project.