### PR TITLE
Remove superfluous comment

### DIFF
--- a/crates/zoroswap/src/trading_engine.rs
+++ b/crates/zoroswap/src/trading_engine.rs
@@ -422,8 +422,6 @@ impl TradingEngine {
                     // TODO: check for
                     //       ERR_MAX_COVERAGE_RATIO_EXCEEDED +
                     //       ERR_RESERVE_WITH_SLIPPAGE_EXCEEDS_ASSET_BALANCE
-
-                    // Check if order is past deadline
                     info!(
                         "SWAP: in {} from faucet {}, out {} from faucet {} at price {}",
                         order.asset_in.amount(),


### PR DESCRIPTION
I believe the comment was meant as a todo.

But the check is already implemented in code that comes before. At line 320, before the `match order.order_type` block is entered, every order is checked:
```rust
if order.deadline < now {
    // push OrderExecution::PastDeadline
    continue;
}
```                                                                                                                                                                                                               

This `continue` skips the entire `match order.order_type` block, so by the time the `OrderType::Swap` arm at line 421 is reached, the order is guaranteed to not be past its deadline.
              