### PR TITLE
Move oracle lookup into Swap branch

### DIFF
--- a/crates/zoroswap/src/trading_engine.rs
+++ b/crates/zoroswap/src/trading_engine.rs
@@ -331,13 +331,6 @@ impl TradingEngine {
                 }));
                 continue;
             }
-            let price = {
-                self.state.oracle_price_for_pair(
-                    order.asset_in.faucet_id(),
-                    order.asset_out.faucet_id(),
-                )?
-            };
-
             match order.order_type {
                 OrderType::Deposit => {
                     let (amount_out, new_pool_state) = get_deposit_lp_amount_out(
@@ -425,6 +418,10 @@ impl TradingEngine {
                     }
                 }
                 OrderType::Swap => {
+                    let price = self.state.oracle_price_for_pair(
+                        order.asset_in.faucet_id(),
+                        order.asset_out.faucet_id(),
+                    )?;
                     // TODO: check for
                     //       ERR_MAX_COVERAGE_RATIO_EXCEEDED +
                     //       ERR_RESERVE_WITH_SLIPPAGE_EXCEEDS_ASSET_BALANCE


### PR DESCRIPTION
In `main` the oracle price is fetched for every order. Currently, only Swap orders utilize the `price` though. 

As the lookup is a fallible operation, an oracle error aborts the entire matching cycle (so also for deposits and withdrawals that don't utilize the price).